### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/Andsc1604/juice-shop-ada-1466/security/code-scanning/54](https://github.com/Andsc1604/juice-shop-ada-1466/security/code-scanning/54)

To prevent code injection, user input must **never** be included in dynamically evaluated code. MongoDB's `$where` operator is especially dangerous and should be avoided. For this case, since we're searching by an order ID, we should use a standard MongoDB query (`{ orderId: id }`), which does not allow user input to influence code execution and is safe when used with well-sanitized data. The single best fix is to replace the `$where` usage with a standard field-based query, e.g. `find({ orderId: id })`. No new imports or helper functions are required; only the query on line 18 needs to be adjusted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
