### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -28,12 +28,15 @@ global.sleep = (time: number) => {
 export function showProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     // Truncate id to avoid unintentional RCE
-    const id = !utils.isChallengeEnabled(challenges.noSqlCommandChallenge) ? Number(req.params.id) : utils.trunc(req.params.id, 40)
+    const idChallengeEnabled = utils.isChallengeEnabled(challenges.noSqlCommandChallenge)
+    const id = idChallengeEnabled ? utils.trunc(req.params.id, 40) : Number(req.params.id)
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    // SAFE QUERY: Avoid $where, use direct property match
+    const productQuery = idChallengeEnabled ? { product: id } : { product: Number(id) }
+    db.reviewsCollection.find(productQuery).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/Andsc1604/juice-shop-ada-1466/security/code-scanning/53](https://github.com/Andsc1604/juice-shop-ada-1466/security/code-scanning/53)

The best way to fix this problem is to avoid using the `$where` operator with user-controlled input. Instead, use direct MongoDB query operators with input validation or casting. In this concrete case, rather than searching for reviews with `$where: 'this.product == ' + id`, we should use `{ product: id }` and ensure that the type matches what is stored in the database (likely a number or a string). 

To implement this:
- In `routes/showProductReviews.ts`, within the `showProductReviews` function, replace the line that calls `.find({ $where: 'this.product == ' + id })` with one that calls `.find({ product: castedId })`.
- Also, sanitize and convert the `id` parameter as necessary. If you want to maintain the challenge logic (switching behavior depending on a challenge being enabled), consider implementing a simulated vulnerability safely, e.g., by only enabling the dangerous behavior for the challenge, but for secure production, always use the direct query.

No changes are needed in `lib/utils.ts`, as the core fix is in the route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
